### PR TITLE
Feat/#42 복약 체크리스트 수정 및 메인 그래프 수정

### DIFF
--- a/wear/src/main/java/com/epi/epilog/presentation/BloodSugarInputFragment.kt
+++ b/wear/src/main/java/com/epi/epilog/presentation/BloodSugarInputFragment.kt
@@ -1,115 +1,10 @@
-//package com.epi.epilog.presentation
-//
-//import android.content.Context
-//import android.content.Intent
-//import android.os.Bundle
-//import android.util.Log
-//import android.view.LayoutInflater
-//import android.view.View
-//import android.view.ViewGroup
-//import android.widget.Button
-//import android.widget.EditText
-//import android.widget.ScrollView
-//import androidx.fragment.app.Fragment
-//import com.epi.epilog.R
-//import com.epi.epilog.presentation.theme.api.RetrofitService
-//import com.google.gson.Gson
-//import retrofit2.Call
-//import retrofit2.Callback
-//import retrofit2.Response
-//import retrofit2.Retrofit
-//import retrofit2.converter.gson.GsonConverterFactory
-//
-//class BloodSugarInputFragment : Fragment() {
-//
-//    override fun onCreateView(
-//        inflater: LayoutInflater, container: ViewGroup?,
-//        savedInstanceState: Bundle?
-//    ): View? {
-//        // Inflate the layout for this fragment
-//        return inflater.inflate(R.layout.fragment_blood_sugar_input, container, false)
-//    }
-//
-//    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-//        super.onViewCreated(view, savedInstanceState)
-//
-//        val scrollView = activity?.findViewById<ScrollView>(R.id.blood_sugar_scroll)
-//        scrollView?.scrollTo(0, 0)
-//
-//        val date = activity?.intent?.getStringExtra("SELECTED_DATE") ?: ""
-//        val occurrenceType = arguments?.getString("occurrenceType") ?: ""
-//        val bloodSugarInput = view.findViewById<EditText>(R.id.bloodSugarLevelInput)
-//
-//        val submitButton = view.findViewById<Button>(R.id.blood_sugar_submit_btn)
-//        submitButton.setOnClickListener {
-//            val bloodSugar = bloodSugarInput.text.toString().toInt()
-//
-//            Log.d("BloodSugarInputFragment", "Sending data - date: $date, occurrenceType: $occurrenceType, bloodSugar: $bloodSugar")
-//
-//            val bloodData = Blood(
-//                date = date,
-//                occurrenceType = occurrenceType,
-//                bloodSugar = bloodSugar
-//            )
-//
-//            // Log the data being sent
-//            val gson = Gson()
-//            val bloodDataJson = gson.toJson(bloodData)
-//            Log.d("BloodSugarInputFragment", "Blood Data JSON: $bloodDataJson")
-//
-//            // Get the token from SharedPreferences
-//            val sharedPreferences = requireActivity().getSharedPreferences("AppPrefs", Context.MODE_PRIVATE)
-//            val token = sharedPreferences.getString("AuthToken", "")
-//            if (token.isNullOrEmpty()) {
-//                Log.d("BloodSugarTimeInput", "Auth token is missing.")
-//                return@setOnClickListener
-//            }
-//
-//            val retrofitService = createRetrofitService() // RetrofitService 객체 생성
-//            val call = retrofitService.postBloodSugarData(bloodData, "Bearer $token")
-//            call.enqueue(object : Callback<ApiResponse> {
-//                override fun onResponse(call: Call<ApiResponse>, response: Response<ApiResponse>) {
-//                    if (response.isSuccessful) {
-//                        response.body()?.let { apiResponse ->
-//                            Log.d("BloodSugarInputFragment", "Response: ${apiResponse.message}, Success: ${apiResponse.success}")
-//                            if (apiResponse.success) {
-//                                val intent = Intent(requireActivity(), MainActivity::class.java)
-//                                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
-//                                startActivity(intent)
-//                            }
-//                        }
-//                    } else {
-//                        val errorBody = response.errorBody()?.string()
-//                        Log.e("BloodSugarInputFragment", "Response was not successful: Code ${response.code()}, Error Body: $errorBody")
-//                    }
-//                }
-//
-//                override fun onFailure(call: Call<ApiResponse>, t: Throwable) {
-//                    Log.e("BloodSugarInputFragment", "Failed to post data", t)
-//                }
-//            })
-//        }
-//
-//    }
-//
-//    companion object {
-//        private const val BASE_URL = "http://epilog-develop-env.eba-imw3vi3g.ap-northeast-2.elasticbeanstalk.com/"
-//
-//        fun createRetrofitService(): RetrofitService {
-//            val retrofit = Retrofit.Builder()
-//                .baseUrl(BASE_URL)
-//                .addConverterFactory(GsonConverterFactory.create())
-//                .build()
-//            return retrofit.create(RetrofitService::class.java)
-//        }
-//    }
-//}
-
 package com.epi.epilog.presentation
 
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -117,6 +12,9 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ScrollView
+import android.widget.Toast
+import androidx.compose.ui.graphics.Color
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.epi.epilog.R
 import com.epi.epilog.presentation.theme.api.RetrofitService
@@ -146,12 +44,40 @@ class BloodSugarInputFragment : Fragment() {
         val date = activity?.intent?.getStringExtra("SELECTED_DATE") ?: ""
         val occurrenceType = arguments?.getString("occurrenceType") ?: ""
         val bloodSugarInput = view.findViewById<EditText>(R.id.bloodSugarLevelInput)
-
         val submitButton = view.findViewById<Button>(R.id.blood_sugar_submit_btn)
+        submitButton.isEnabled = false
+
+        // TextWatcher를 사용하여 텍스트 변경 감지 및 색상 변경
+        bloodSugarInput.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+
+            override fun afterTextChanged(s: Editable?) {
+                val bloodSugarValue: Int?
+                try {
+                    bloodSugarValue = s.toString().toInt()
+                    if (bloodSugarValue > 350) {
+                        bloodSugarInput.setTextColor(ContextCompat.getColor(requireContext(), R.color.빨강))
+                        Toast.makeText(requireContext(), "혈당 수치는 350까지 기록 가능합니다!", Toast.LENGTH_SHORT).show()
+                        submitButton.isEnabled = false
+                    } else {
+                        bloodSugarInput.setTextColor(ContextCompat.getColor(requireContext(), R.color.검정색))
+                        submitButton.isEnabled = true
+                    }
+                } catch (e: NumberFormatException) {
+                    bloodSugarInput.setTextColor(ContextCompat.getColor(requireContext(), R.color.검정색))
+                    submitButton.isEnabled = false
+                }
+            }
+        })
+
+
         submitButton.setOnClickListener {
             val bloodSugar = bloodSugarInput.text.toString().toInt()
 
             Log.d("BloodSugarInputFragment", "Sending data - date: $date, occurrenceType: $occurrenceType, bloodSugar: $bloodSugar")
+            Toast.makeText(requireContext(), "혈당기록 저장됨", Toast.LENGTH_LONG).show()
 
             val bloodData = Blood(
                 date = date,
@@ -180,9 +106,10 @@ class BloodSugarInputFragment : Fragment() {
                         response.body()?.let { apiResponse ->
                             Log.d("BloodSugarInputFragment", "Response: ${apiResponse.message}, Success: ${apiResponse.success}")
                             if (apiResponse.success) {
-                                // 성공적으로 데이터를 전송한 후 메인 액티비티로 이동
-                                val intent = Intent(requireActivity(), MainActivity::class.java)
-                                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+                                val intent = Intent(requireActivity(), MainActivity::class.java).apply {
+                                    flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+                                    putExtra("SELECTED_DATE", date)
+                                }
                                 startActivity(intent)
                             }
                         }

--- a/wear/src/main/java/com/epi/epilog/presentation/CalendarInitializer.kt
+++ b/wear/src/main/java/com/epi/epilog/presentation/CalendarInitializer.kt
@@ -31,6 +31,12 @@ class CalendarInitializer(
         return selectedDate
     }
 
+    fun selectDate(date: LocalDate) {
+        selectedDate = date
+        weekCalendarView.notifyDateChanged(date)
+        Toast.makeText(context, "선택된 날짜: $date", Toast.LENGTH_SHORT).show()
+    }
+
     fun initWeekCalendarView() {
         weekCalendarView.dayBinder = object : WeekDayBinder<DayViewContainer> {
             override fun create(view: View) = DayViewContainer(view)

--- a/wear/src/main/java/com/epi/epilog/presentation/ChartInitializer.kt
+++ b/wear/src/main/java/com/epi/epilog/presentation/ChartInitializer.kt
@@ -1,14 +1,15 @@
+package com.epi.epilog.presentation
+
 import android.content.Context
 import android.graphics.Color
 import android.util.Log
-import com.epi.epilog.presentation.BloodSugarDatas
 import com.epi.epilog.presentation.theme.api.RetrofitService
 import com.github.mikephil.charting.charts.LineChart
-import com.github.mikephil.charting.components.XAxis
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.data.LineData
 import com.github.mikephil.charting.data.LineDataSet
 import com.github.mikephil.charting.formatter.ValueFormatter
+import com.github.mikephil.charting.components.XAxis
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -22,7 +23,6 @@ class ChartInitializer(private val chart: LineChart) {
     private val bloodSugarChartData = ArrayList<Entry>()
     private lateinit var lineData: LineData
     private lateinit var retrofitService: RetrofitService
-
 
     fun initChart() {
         initializeRetrofit() // Retrofit 초기화
@@ -79,6 +79,9 @@ class ChartInitializer(private val chart: LineChart) {
 
     private fun handleNoData() {
         Log.w("ChartInitializer", "No data available")
+        bloodSugarChartData.clear()
+        chart.clear()
+        chart.invalidate()
     }
 
     private fun handleResponseError(response: Response<BloodSugarDatas>) {

--- a/wear/src/main/java/com/epi/epilog/presentation/DayViewContainer.kt
+++ b/wear/src/main/java/com/epi/epilog/presentation/DayViewContainer.kt
@@ -7,7 +7,4 @@ import com.kizitonwose.calendar.view.ViewContainer
 
 class DayViewContainer(view: View) : ViewContainer(view) {
     val textView = view.findViewById<TextView>(R.id.calendarDayText)
-
-    // With ViewBinding
-    // val textView = CalendarDayLayoutBinding.bind(view).calendarDayText
 }

--- a/wear/src/main/java/com/epi/epilog/presentation/MainActivity.kt
+++ b/wear/src/main/java/com/epi/epilog/presentation/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.epi.epilog.presentation
 
 import CalendarInitializer
-import ChartInitializer
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
@@ -80,6 +79,15 @@ class MainActivity : ComponentActivity() {
 
         // FallDetectionService 실행
         startFallDetectionService()
+
+        // Intent로 전달된 날짜가 있는지 확인하고, 있으면 해당 날짜로 차트를 업데이트
+        val selectedDate = intent.getStringExtra("SELECTED_DATE")?.let {
+            LocalDate.parse(it)
+        }
+        selectedDate?.let {
+            onDateSelected(it)
+            calendarInitializer.selectDate(it)
+        }
 
     }
 

--- a/wear/src/main/res/layout/fragment_blood_sugar_input.xml
+++ b/wear/src/main/res/layout/fragment_blood_sugar_input.xml
@@ -24,7 +24,6 @@
                 android:layout_weight="3"
                 android:hint="혈당수치 입력"
                 android:textSize="16dp"
-                android:textColor="@color/검정색"
                 android:inputType="numberDecimal"
                 android:gravity="center_horizontal"
                 android:layout_gravity="center"


### PR DESCRIPTION
- [x]  서버 api 연결코드 작성
- [x]  서버 api 연결 잘 된건지 확인
- [x]  오늘의 혈당 기록 개수 체크해서 그래프 동적으로 수정
- [x]  오늘의 혈당 기록 개수(total) 체크해서 텍스트 뷰 수정
- [x]  날짜 키 값으로 받아서 동적으로 수정되도록 (현재는 고정 날짜로 일일히 테스트 해봄)
- [x]  혈당 350 오버는 빨간색으로 표시되고 입력될 수 없게끔 수정
- [x]  '시간으로 기록하기' 다음 누르면 메인으로 가도록 수정
- [x]  혈당 기록하기 → 기록 완료 후 토스트 안내
- [x]  메인 그래프 기록없는 창 이전 기록 끌어오는 문제 해결
- [x]  혈당 기록했을 시 그 날짜 화면을 디폴트로 돌아가고, 아니면 오늘날짜 기본 값으로
- [x]  복약 체크리스트 수정(get)